### PR TITLE
Set default maxBoost to 1.1 using the new nupic_model_params

### DIFF
--- a/monitor/run_monitor_dyn.py
+++ b/monitor/run_monitor_dyn.py
@@ -110,7 +110,8 @@ def new_monitor(check_id, config):
                       'webhook': None,
                       'likelihood_threshold': None,
                       'anomaly_threshold': 0.9,
-                      'domain': 'localhost'}
+                      'domain': 'localhost',
+                      'nupic_model_params': {'spParams': {'maxBoost': 1.1}}}
     monitor_config.update(config)
 
     logger.info("Monitor configuration: %s", monitor_config)


### PR DESCRIPTION
Setting the default - does this look right? this is the dict passed to the Monitor constructor. 